### PR TITLE
fix: remove redundant main tag in App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <Navbar />
     <BackgroundFX />
 
-    <main>
+    <main class="layout-main">
       <Hero data-scene="0" />
 
       <section id="services" class="container section" data-scene="1">


### PR DESCRIPTION
## Summary
- ensure the layout uses a single `<main class="layout-main">` wrapper

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b508928838832a9342cc694ac5da20